### PR TITLE
getinstinct.com has been permenantly shut down

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ A curated list of awesome tools to create, edit and display sheet music.
 - [chromatik] \(commercial\) - Play along to sheet music
   of previously unreleased tunes.
 - [flat.io] - The online music score editor for your compositions.
-- [getinstinct] - Guitar lessons that listen as you play along.
 - [lilybin] - Web-based LilyPond editor and [github] project.
 - [my.vexflow] - Publish content with music notation, guitar tablature
   and chord diagrams without the need for special tools.
@@ -89,7 +88,6 @@ A curated list of awesome tools to create, edit and display sheet music.
 
 [chromatik]: https://chromatik.com
 [flat.io]: https://flat.io
-[getinstinct]: https://getinstinct.com
 [lilybin]: http://lilybin.com
 [my.vexflow]: http://my.vexflow.com
 [noteflight]: http://noteflight.com


### PR DESCRIPTION
As the authors of getinstinct.com write: "As of Dec 31, 2016, Instinct has been permenantly shut down."

They recommend https://soundslice.com (which already in the list) and for piano https://www.flowkey.com.