### PR TITLE
Add mei-friend

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ A curated list of awesome tools to create, edit and display sheet music.
   engraver-quality sheet music.
 - [Gsharp] - Interactive extensible score editor.
 - [LilyPond] - Program and file format for music engraving.
+- [mei-friend] - a friendly, browser-based editor for music encodings.
 - [MuseScore] - Create, play and print sheet music.
 - [opusmodus] \(commercial\) - Software for music composition.
 - [sibelius] \(commercial\) - Create and share scores.
@@ -46,6 +47,7 @@ A curated list of awesome tools to create, edit and display sheet music.
 [finale]: http://finalemusic.com
 [Gsharp]: https://www.common-lisp.net/project/gsharp/
 [LilyPond]: http://lilypond.org
+[mei-friend]: https://mei-friend.mdw.ac.at
 [MuseScore]: http://musescore.org
 [opusmodus]: http://opusmodus.com
 [sibelius]: http://sibelius.com

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ A curated list of awesome tools to create, edit and display sheet music.
   engraver-quality sheet music.
 - [Gsharp] - Interactive extensible score editor.
 - [LilyPond] - Program and file format for music engraving.
-- [mei-friend] - a friendly, browser-based editor for music encodings.
+- [mei-friend](https://mei-friend.mdw.ac.at) - a browser-based editor for music encodings.
 - [MuseScore] - Create, play and print sheet music.
 - [opusmodus] \(commercial\) - Software for music composition.
 - [sibelius] \(commercial\) - Create and share scores.
@@ -47,7 +47,6 @@ A curated list of awesome tools to create, edit and display sheet music.
 [finale]: http://finalemusic.com
 [Gsharp]: https://www.common-lisp.net/project/gsharp/
 [LilyPond]: http://lilypond.org
-[mei-friend]: https://mei-friend.mdw.ac.at
 [MuseScore]: http://musescore.org
 [opusmodus]: http://opusmodus.com
 [sibelius]: http://sibelius.com

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ A curated list of awesome tools to create, edit and display sheet music.
   engraver-quality sheet music.
 - [Gsharp] - Interactive extensible score editor.
 - [LilyPond] - Program and file format for music engraving.
-- [mei-friend](https://mei-friend.mdw.ac.at) - a browser-based editor for music encodings.
+- [mei-friend] - Browser-based editor for music encodings.
 - [MuseScore] - Create, play and print sheet music.
 - [opusmodus] \(commercial\) - Software for music composition.
 - [sibelius] \(commercial\) - Create and share scores.
@@ -47,6 +47,7 @@ A curated list of awesome tools to create, edit and display sheet music.
 [finale]: http://finalemusic.com
 [Gsharp]: https://www.common-lisp.net/project/gsharp/
 [LilyPond]: http://lilypond.org
+[mei-friend]: https://mei-friend.mdw.ac.at
 [MuseScore]: http://musescore.org
 [opusmodus]: http://opusmodus.com
 [sibelius]: http://sibelius.com


### PR DESCRIPTION
This PR adds a link to [mei-friend](https://mei-friend.mdw.ac.at), a browser-based graphical music encoding editor. It is capable of opening encodings in a variety of formats, but converts them to MEI, the format of the [Music Encoding Initiative](https://music-encoding.org) for editing. The editor supports a number of basic and advanced features, documented at https://mei-friend.github.io/. The browser is open-source and community developed, and widely used by members of the MEI, counting typically more than 500 unique user sessions a month at its official instance hosted by mdw - University of Music and Performing Arts Vienna.