### PR TITLE
Add DomiSol (web-based solfa & jianpu score editor)

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ A curated list of awesome tools to create, edit and display sheet music.
 - [ChordMark] - Simple text format for the notation of lyrics, chords and rhythm.
 - [ChordPro] - Simple text format for the notation of lyrics with chords.
 - [Clairnote] - Alternative music notation to ease reading and understanding.
+- [DomiSol] - Web-based score editor for tonic solfa (d r m f s l t) and jianpu (1 2 3 4 5 6 7) notation.
 - [flat.io] \(commercial\) - The online music score editor for your compositions.
 - [flowkey] \(commercial\) - Interactive app to learn how to play the piano.
 - [Fretboard 1] - Chords, scales, and fingerings for string instruments.
@@ -212,6 +213,7 @@ A curated list of awesome tools to create, edit and display sheet music.
 [ChordMark]: https://chordmark.netlify.app/
 [ChordPro]: https://www.chordpro.org
 [Clairnote]: https://clairnote.org
+[DomiSol]: https://domisol.app
 [flat.io]: https://flat.io
 [flowkey]: https://www.flowkey.com/en
 [Fretboard 1]: https://github.com/fredericcormier/Fretboard


### PR DESCRIPTION
Adding DomiSol to the **Websites** section.

DomiSol is a free, web-based score editor where tonic solfa (`d r m f s l t`) and jianpu (`1 2 3 4 5 6 7`) are the editing model, not export formats. It targets the audiences that read those notations natively: African church choirs (Nigerian Methodist, Ghanaian Presbyterian, etc.), Chinese / Taiwanese / Indonesian musicians (erhu, dizi, guzheng, gamelan), and movable-do solfege educators worldwide.

- URL: https://domisol.app
- Free during public beta; persistent free tier planned
- Web-only (Astro + Firebase + Tone.js)
- One-click toggle between solfa and jianpu on any score
- SATB, lyric alignment, PDF export, share-via-URL viewer optimised for low-bandwidth phones

Slotted alphabetically between Clairnote and flat.io. Description follows the existing entry pattern (brief, no superlatives). Reference link added to the bottom block.